### PR TITLE
Remove absolute pathnames from test benchmark comparison

### DIFF
--- a/baselines/reference/test.grammar.diagnostics
+++ b/baselines/reference/test.grammar.diagnostics
@@ -1,11 +1,11 @@
 /// test.grammar:
-C:/dev/grammarkdown/spec/test.grammar(7,1): error GM2006: Production 'D' is missing parameter 'B'. All definitions of production 'D' must specify the same formal parameters.
-C:/dev/grammarkdown/spec/test.grammar(8,1): error GM2006: Production 'D' is missing parameter 'A'. All definitions of production 'D' must specify the same formal parameters.
-C:/dev/grammarkdown/spec/test.grammar(12,5): error GM2007: There is no argument given for parameter 'A'.
-C:/dev/grammarkdown/spec/test.grammar(13,7): error GM1001: '?', '+', or '~' expected.
-C:/dev/grammarkdown/spec/test.grammar(14,7): error GM1001: '?', '+', or '~' expected.
-C:/dev/grammarkdown/spec/test.grammar(14,10): error GM1001: '?', '+', or '~' expected.
-C:/dev/grammarkdown/spec/test.grammar(14,10): error GM2004: Production 'E' does not have a parameter named 'B'.
-C:/dev/grammarkdown/spec/test.grammar(15,5): error GM2007: There is no argument given for parameter 'A'.
-C:/dev/grammarkdown/spec/test.grammar(15,8): error GM2004: Production 'E' does not have a parameter named 'B'.
-C:/dev/grammarkdown/spec/test.grammar(15,8): error GM2004: Production 'F' does not have a parameter named 'B'.
+./spec/test.grammar(7,1): error GM2006: Production 'D' is missing parameter 'B'. All definitions of production 'D' must specify the same formal parameters.
+./spec/test.grammar(8,1): error GM2006: Production 'D' is missing parameter 'A'. All definitions of production 'D' must specify the same formal parameters.
+./spec/test.grammar(12,5): error GM2007: There is no argument given for parameter 'A'.
+./spec/test.grammar(13,7): error GM1001: '?', '+', or '~' expected.
+./spec/test.grammar(14,7): error GM1001: '?', '+', or '~' expected.
+./spec/test.grammar(14,10): error GM1001: '?', '+', or '~' expected.
+./spec/test.grammar(14,10): error GM2004: Production 'E' does not have a parameter named 'B'.
+./spec/test.grammar(15,5): error GM2007: There is no argument given for parameter 'A'.
+./spec/test.grammar(15,8): error GM2004: Production 'E' does not have a parameter named 'B'.
+./spec/test.grammar(15,8): error GM2004: Production 'F' does not have a parameter named 'B'.

--- a/src/tests/diff.ts
+++ b/src/tests/diff.ts
@@ -73,6 +73,12 @@ export function writeDiagnostics(test: string, diagnostics: DiagnosticMessages, 
         text += message + EOL;
     });
 
+    if (!!text) {
+        // Remove absolute pathnames from text
+        const root = resolve(".").replace(/\\/g,"/");
+        const re = new RegExp(root.replace(/[.?*+^$[\]\\(){}|-]/g, "\\$&"), "gi");
+        text = text.replace(re, ".");
+    }
     return writeBaseline(test + ".diagnostics", text, baselines);
 }
 


### PR DESCRIPTION
Closes #22 related to baseline file 'test.grammar.diagnostics' containing absolute path names..
