### PR TITLE
Fix CLI

### DIFF
--- a/bin/grammarkdown
+++ b/bin/grammarkdown
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('../out/lib/cli.js')
+require('../dist/cli.js')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,7 +69,7 @@ function main(): void {
 }
 
 function printUsage(): void {
-    const node_package = <Package>require("../../package.json");
+    const node_package = <Package>require("../package.json");
     usage(knownOptions, 36, (writer) => {
         writer.writeln(`Version ${node_package.version}`);
         writer.writeOption("Syntax:", "grammarkdown [options] [...files]");
@@ -82,7 +82,7 @@ function printUsage(): void {
 }
 
 function printVersion(): void {
-    const node_package = <Package>require("../../package.json");
+    const node_package = <Package>require("../package.json");
     console.log(node_package.version);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,12 +101,12 @@ function performCompilation(options: ParsedCommandLine): void {
 
     const inputFiles = options.rest;
     const grammar = new Grammar(inputFiles, compilerOptions);
-    grammar.bind();
-    grammar.check();
+    grammar.bindSync();
+    grammar.checkSync();
 
     if (!compilerOptions.noEmit) {
         if (!compilerOptions.noEmitOnError || grammar.diagnostics.size <= 0) {
-            grammar.emit();
+            grammar.emitSync();
         }
     }
 

--- a/src/tests/cli-tests.ts
+++ b/src/tests/cli-tests.ts
@@ -1,0 +1,24 @@
+import { assert } from "chai";
+import { execSync } from "child_process";
+
+describe("cli", () => {
+  it("exits cleanly when given good input", () => {
+    execSync("node bin/grammarkdown src/tests/resources/specs/es6.grammar --noEmit", { stdio: "ignore", encoding: "utf8" });
+  });
+
+  it("exits with an error when given bad input", () => {
+    assert.throws(() => {
+      execSync("node bin/grammarkdown src/tests/resources/specs/test.grammar --noEmit", { stdio: "ignore", encoding: "utf8" });
+    });
+  });
+
+  it("prints help given --help", () => {
+    let help = execSync("node bin/grammarkdown --help", { encoding: "utf8" });
+    assert(/Prints this message/.test(help));
+  });
+
+  it("prints version given --version", () => {
+    let version = execSync("node bin/grammarkdown --version", { encoding: "utf8" });
+    assert.strictEqual(version.trim(), process.env.npm_package_version.trim());
+  });
+});

--- a/src/tests/grammar-tests.ts
+++ b/src/tests/grammar-tests.ts
@@ -7,7 +7,7 @@ import { Parser } from "../parser";
 import { Grammar } from "../grammar";
 import { EmitFormat, NewLineKind } from "../options";
 
-describe.only("Grammar", () => {
+describe("Grammar", () => {
     defineSuites();
 
     function defineSuites() {

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -22,3 +22,4 @@ import "./navigator-tests";
 import "./checker-tests";
 import "./emitter-tests";
 import "./grammar-tests";
+import "./cli-tests";


### PR DESCRIPTION
Five commits:

- change a `describe.only` to `describe` so that the full test suite actually runs
- make the CLI work (fixes https://github.com/rbuckton/grammarkdown/issues/40)
- make `--help` and `--version` on the CLI work
- make the CLI fail when there's errors, as seems to have been intended (by using sync APIs)
- add tests for the previous three items