### PR TITLE
deprecate 'prex' usage in favor of '@esfx/cancelable'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,20 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@esfx/async-canceltoken": {
+      "version": "1.0.0-pre.13",
+      "resolved": "https://registry.npmjs.org/@esfx/async-canceltoken/-/async-canceltoken-1.0.0-pre.13.tgz",
+      "integrity": "sha512-D8OF4aZWRuJDW9FAV8D8JB4umDvBpd6VF82Pybh/tFJ9FqIjZ80aURPwYDhQkK+9coF//Qx3zfsLO6ifSpjJJQ==",
+      "dev": true,
+      "requires": {
+        "@esfx/cancelable": "^1.0.0-pre.13",
+        "@esfx/collections-linkedlist": "^1.0.0-pre.13",
+        "@esfx/disposable": "^1.0.0-pre.13",
+        "@esfx/internal-guards": "^1.0.0-pre.11",
+        "@esfx/internal-tag": "^1.0.0-pre.6",
+        "tslib": "^1.9.3"
+      }
+    },
     "@esfx/cancelable": {
       "version": "1.0.0-pre.13",
       "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.13.tgz",
@@ -17,6 +31,29 @@
         "tslib": "^1.9.3"
       }
     },
+    "@esfx/collection-core": {
+      "version": "1.0.0-pre.13",
+      "resolved": "https://registry.npmjs.org/@esfx/collection-core/-/collection-core-1.0.0-pre.13.tgz",
+      "integrity": "sha512-jMOy2238UjUeHC0sRVaNeJ2koK/YLZxITKTLbZfWUJpfp/4UVmDO/npv0cxIcob59KdWRf5MONjgz2WdzNpU+A==",
+      "dev": true,
+      "requires": {
+        "@esfx/internal-deprecate": "^1.0.0-pre.13",
+        "@esfx/internal-guards": "^1.0.0-pre.11",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@esfx/collections-linkedlist": {
+      "version": "1.0.0-pre.13",
+      "resolved": "https://registry.npmjs.org/@esfx/collections-linkedlist/-/collections-linkedlist-1.0.0-pre.13.tgz",
+      "integrity": "sha512-rddmq8BWGxo0rnobqexp1XTF1iJqezxemPHgAvJBD8dLVowrZ/ffVkj5wjmbHtaTh2qwHhJ/kThyyT9/RzLKJg==",
+      "dev": true,
+      "requires": {
+        "@esfx/collection-core": "^1.0.0-pre.13",
+        "@esfx/equatable": "^1.0.0-pre.13",
+        "@esfx/internal-guards": "^1.0.0-pre.11",
+        "tslib": "^1.9.3"
+      }
+    },
     "@esfx/disposable": {
       "version": "1.0.0-pre.13",
       "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.13.tgz",
@@ -26,6 +63,17 @@
         "@esfx/internal-deprecate": "^1.0.0-pre.13",
         "@esfx/internal-guards": "^1.0.0-pre.11",
         "@esfx/internal-tag": "^1.0.0-pre.6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@esfx/equatable": {
+      "version": "1.0.0-pre.13",
+      "resolved": "https://registry.npmjs.org/@esfx/equatable/-/equatable-1.0.0-pre.13.tgz",
+      "integrity": "sha512-2vYdGp5yCPB0HFLqetOqTVBuUfxos38La195fkeGJilNF/hZ1Zvwx2nrMuwyypKn5lyCZ9GgxJ5XlvY/rV8EwA==",
+      "dev": true,
+      "requires": {
+        "@esfx/internal-deprecate": "^1.0.0-pre.13",
+        "@esfx/internal-hashcode": "^1.0.0-pre.9",
         "tslib": "^1.9.3"
       }
     },
@@ -45,6 +93,25 @@
       "dev": true,
       "requires": {
         "@esfx/type-model": "^1.0.0-pre.11",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@esfx/internal-hashcode": {
+      "version": "1.0.0-pre.9",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-hashcode/-/internal-hashcode-1.0.0-pre.9.tgz",
+      "integrity": "sha512-TJ43s8iE6wnVHT3CyIaRIZRlOOFIlK7m0hk1fl2D0ZzrTLtw5GUEcMFqV2sIGkGXrEKjEqwkuK1/vPQl9rikvA==",
+      "dev": true,
+      "requires": {
+        "@esfx/internal-murmur3": "^1.0.0-pre.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@esfx/internal-murmur3": {
+      "version": "1.0.0-pre.5",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-murmur3/-/internal-murmur3-1.0.0-pre.5.tgz",
+      "integrity": "sha512-Jq+oO1sbxWeUvIoyS7tOF+jg1KLitOOD1/TPTmdYGu/ss53kM8GXaGw5H4x/g07tQfQdC3QyDlepxK/dvoQqoQ==",
+      "dev": true,
+      "requires": {
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "prex": "^0.4.2"
+    "prex": "^0.4.2",
+    "@esfx/async-canceltoken": "^1.0.0-pre.13",
+    "@esfx/cancelable": "^1.0.0-pre.13"
   }
 }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -13,10 +13,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 import { binarySearch, compareStrings, compare, Range, Position } from "./core";
 import { CharacterCodes, SyntaxKind, tokenToString } from "./tokens";
 import { Node, SourceFile } from "./nodes";
-import { skipTrivia } from "./scanner";
 
 export interface Diagnostic {
     code: number;
@@ -360,7 +360,6 @@ export class DiagnosticMessages {
         if (indices.length <= 1) {
             return indices;
         }
-        const numIndices = indices.length;
         const firstDiagnosticIndex = indices[0];
         const newIndices: number[] = [firstDiagnosticIndex];
         let previousDiagnosticIndex = firstDiagnosticIndex;
@@ -546,14 +545,6 @@ export class LineMap {
         }
         lineStarts.push(lineStart);
         this.lineStarts = lineStarts;
-    }
-
-    private isLineBreak(ch: number): boolean {
-        return ch === CharacterCodes.CarriageReturn
-            || ch === CharacterCodes.LineFeed
-            || ch === CharacterCodes.LineSeparator
-            || ch === CharacterCodes.ParagraphSeparator
-            || ch === CharacterCodes.NextLine;
     }
 }
 

--- a/src/emitter/ecmarkup.ts
+++ b/src/emitter/ecmarkup.ts
@@ -1,20 +1,31 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { Emitter } from "./emitter";
 import { SyntaxKind } from "../tokens";
-import { DiagnosticMessages } from "../diagnostics";
-import { Checker } from "../checker";
 import {
     Node,
-    SourceFile,
     UnicodeCharacterLiteral,
     UnicodeCharacterRange,
     Prose,
-    Identifier,
     Parameter,
     ParameterList,
     OneOfList,
     Terminal,
     SymbolSet,
-    Assertion,
     EmptyAssertion,
     LookaheadAssertion,
     NoSymbolHereAssertion,
@@ -31,7 +42,6 @@ import {
     RightHandSide,
     RightHandSideList,
     Production,
-    SourceElement,
     TextContent
 } from "../nodes";
 

--- a/src/emitter/html.ts
+++ b/src/emitter/html.ts
@@ -1,20 +1,32 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { Emitter } from "./emitter";
 import { SyntaxKind } from "../tokens";
-import { DiagnosticMessages } from "../diagnostics";
-import { Checker } from "../checker";
 import {
     Node,
     SourceFile,
     UnicodeCharacterLiteral,
     UnicodeCharacterRange,
     Prose,
-    Identifier,
     Parameter,
     ParameterList,
     OneOfList,
     Terminal,
     SymbolSet,
-    Assertion,
     EmptyAssertion,
     LookaheadAssertion,
     NoSymbolHereAssertion,
@@ -31,7 +43,6 @@ import {
     RightHandSide,
     RightHandSideList,
     Production,
-    SourceElement,
     TextContent
 } from "../nodes";
 

--- a/src/emitter/markdown.ts
+++ b/src/emitter/markdown.ts
@@ -1,21 +1,30 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { Emitter } from "./emitter";
 import { SyntaxKind } from "../tokens";
-import { DiagnosticMessages } from "../diagnostics";
-import { Checker } from "../checker";
-import { SymbolKind } from "../symbols";
 import {
     Node,
-    SourceFile,
     UnicodeCharacterLiteral,
     UnicodeCharacterRange,
-    Prose,
-    Identifier,
     Parameter,
     ParameterList,
     OneOfList,
     Terminal,
     SymbolSet,
-    Assertion,
     EmptyAssertion,
     LookaheadAssertion,
     NoSymbolHereAssertion,
@@ -26,13 +35,11 @@ import {
     ArgumentList,
     Nonterminal,
     OneOfSymbol,
-    LexicalSymbol,
     ButNotSymbol,
     SymbolSpan,
     RightHandSide,
     RightHandSideList,
     Production,
-    SourceElement,
     TextContent
 } from "../nodes";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 export { Position, Range } from "./core";
 export * from "./host";
 export * from "./diagnostics";

--- a/src/navigator.ts
+++ b/src/navigator.ts
@@ -1,10 +1,25 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import {
     SourceFile,
-    Node,
+    Node
 } from "./nodes";
 import {
-    Position,
-    Range,
+    Position
 } from "./core";
 import {
     SyntaxKind

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -13,10 +13,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Range, Position, TextRange, emptyIterable, forEach, first, last } from "./core";
+
+import { TextRange, emptyIterable, forEach, first, last } from "./core";
 import { LineMap, DiagnosticMessages } from "./diagnostics";
-import { SyntaxKind, ProseFragmentLiteralKind, LookaheadOperatorKind, ArgumentOperatorKind, ParameterOperatorKind, BooleanKind, ProductionSeperatorKind, TokenKind, CommentTriviaKind, HtmlTriviaKind, TriviaKind } from "./tokens";
-import { SymbolTable } from "./symbols";
+import { SyntaxKind, ProseFragmentLiteralKind, LookaheadOperatorKind, ArgumentOperatorKind, BooleanKind, ProductionSeperatorKind, TokenKind, CommentTriviaKind, HtmlTriviaKind, TriviaKind } from "./tokens";
 import { NodeVisitor } from "./visitor";
 import { skipTrivia } from "./scanner";
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,5 +1,21 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { readFileSync } from "fs";
-import { DictionaryLike, mapFromObject } from "./core";
+import { mapFromObject } from "./core";
 import { CharacterCodes } from "./tokens";
 
 export enum NewLineKind {
@@ -100,15 +116,11 @@ export class UsageWriter {
     private margin: number;
     private padding: number;
     private remainder: number;
-    private marginText: string;
-    private paddingText: string;
 
     constructor(margin: number, padding: number) {
         this.margin = margin;
         this.padding = padding;
         this.remainder = 120 - margin - padding;
-        this.marginText = padRight("", margin);
-        this.paddingText = padRight("", padding);
     }
 
     public writeOption(left: string | undefined, right: string | undefined) {
@@ -207,8 +219,6 @@ export function usage(options: KnownOptions, margin: number = 0, printHeader?: (
 
     knownOptions.sort(compareKnownOptions);
 
-    const descriptionSize = 120 - margin;
-    const marginText = padRight("", margin);
     for (const option of knownOptions) {
         let left = " ";
         if (option.shortName) {
@@ -226,11 +236,6 @@ export function usage(options: KnownOptions, margin: number = 0, printHeader?: (
         left = padRight(left, margin);
         writer.writeOption(left, option.description);
     }
-}
-
-function padLeft(text: string, size: number, char: string = " ") {
-    while (text.length < size) text = char + text;
-    return text;
 }
 
 function padRight(text: string, size: number, char: string = " ") {

--- a/src/performance.ts
+++ b/src/performance.ts
@@ -1,3 +1,19 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 const timestamp = Date.now ? () => Date.now() : () => +(new Date());
 const counts = new Map<string, number>();
 const marks = new Map<string, number>();

--- a/src/read-package.ts
+++ b/src/read-package.ts
@@ -1,3 +1,19 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { readFile, readFileSync } from "fs";
 
 export interface Person {

--- a/src/stringwriter.ts
+++ b/src/stringwriter.ts
@@ -1,3 +1,19 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { EOL } from 'os';
 
 export class StringWriter {

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,3 +1,19 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 let nextSymbolId = 0;
 
 export enum SymbolKind {

--- a/src/tests/checker-tests.ts
+++ b/src/tests/checker-tests.ts
@@ -1,11 +1,27 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { assert } from "chai";
+import { CancelToken } from "@esfx/async-canceltoken";
 import { Grammar } from "../grammar";
 import { Host } from "../host";
-import { CancellationTokenSource } from "prex";
-import { assert } from "chai";
 
 describe("Checker", () => {
     it("cancelable", async () => {
-        const cts = new CancellationTokenSource();
+        const cts = CancelToken.source();
         const grammar = new Grammar(["cancelable.grammar"], {}, new class extends Host {
             async readFile(file: string) { return ""; }
             async writeFile(file: string, content: string) { }

--- a/src/tests/diff.ts
+++ b/src/tests/diff.ts
@@ -13,11 +13,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { readFileSync, writeFileSync, mkdirSync, existsSync, statSync, unlinkSync, mkdir } from "fs";
-import { EOL } from "os";
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, unlinkSync } from "fs";
 import { resolve, basename, dirname } from "path";
 import { Scanner } from "../scanner";
-import { SyntaxKind, tokenToString, CharacterCodes, formatKind } from "../tokens";
+import { SyntaxKind, tokenToString, formatKind } from "../tokens";
 import { DiagnosticMessages, LineMap } from "../diagnostics";
 import {
     SourceFile,
@@ -26,7 +26,6 @@ import {
     StringLiteral,
     Nonterminal,
     Argument,
-    Prose,
     ProseFragmentLiteral,
     Terminal,
     UnicodeCharacterLiteral,

--- a/src/tests/emitter-tests.ts
+++ b/src/tests/emitter-tests.ts
@@ -1,11 +1,27 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { assert } from "chai";
+import { CancelToken } from "@esfx/async-canceltoken";
 import { Grammar } from "../grammar";
 import { Host } from "../host";
-import { CancellationTokenSource } from "prex";
-import { assert } from "chai";
 
 describe("Emitter", () => {
     it("cancelable", async () => {
-        const cts = new CancellationTokenSource();
+        const cts = CancelToken.source();
         const grammar = new Grammar(["cancelable.grammar"], {}, new class extends Host {
             async readFile(file: string) { return ""; }
             async writeFile(file: string, content: string) { }

--- a/src/tests/grammar-tests.ts
+++ b/src/tests/grammar-tests.ts
@@ -1,3 +1,19 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { getGrammarFiles, TestFile, TestFileHost } from "./resources";
 import { SourceFile } from "../nodes";
 import { DiagnosticMessages } from "../diagnostics";

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -13,8 +13,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { install } from "source-map-support";
-install();
+
+import "source-map-support/register";
 
 import "./scanner-tests";
 import "./parser-tests";

--- a/src/tests/navigator-tests.ts
+++ b/src/tests/navigator-tests.ts
@@ -1,7 +1,20 @@
-import { readFileSync } from "fs";
-import { resolve } from "path";
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { Production, RightHandSideList, RightHandSide, Nonterminal } from "../nodes";
-import { DiagnosticMessages } from "../diagnostics";
 import { Parser } from "../parser";
 import { NodeNavigator } from "../navigator";
 import { SyntaxKind } from "../tokens";
@@ -108,7 +121,7 @@ ExportSpecifier :
     });
 
     it("moveToNextSibling (in object)", () => {
-        const { sourceFile, navigator } = getNavigator();
+        const { navigator } = getNavigator();
         navigator.moveToFirstChild();
         const movedToFirstChild = navigator.moveToFirstChild();
         const production = <Production>navigator.getParent();
@@ -144,7 +157,7 @@ ExportSpecifier :
     });
 
     it("moveTopPreviousSibling (in object)", () => {
-        const { sourceFile, navigator } = getNavigator();
+        const { navigator } = getNavigator();
         navigator.moveToFirstChild();
         const movedToLastChild = navigator.moveToLastChild();
         const production = <Production>navigator.getParent();

--- a/src/tests/parser-tests.ts
+++ b/src/tests/parser-tests.ts
@@ -1,10 +1,26 @@
-import { Parser } from "../parser";
-import { CancellationTokenSource } from "prex";
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { assert } from "chai";
+import { CancelToken } from "@esfx/async-canceltoken";
+import { Parser } from "../parser";
 
 describe("Parser", () => {
     it("cancelable", () => {
-        const cts = new CancellationTokenSource();
+        const cts = CancelToken.source();
         const parser = new Parser();
         cts.cancel();
         assert.throws(() => parser.parseSourceFile("cancelable.grammar", "", cts.token));

--- a/src/tests/resources.ts
+++ b/src/tests/resources.ts
@@ -1,7 +1,23 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { readdirSync, statSync, existsSync, readFileSync } from "fs";
-import { resolve, extname, join, posix } from "path";
+import { resolve, extname, posix } from "path";
 import { Host, HostOptions } from "../host";
-import { CancellationToken } from "prex";
+import { Cancelable } from "@esfx/cancelable";
 
 let grammarFiles: TestFile[];
 
@@ -34,12 +50,12 @@ export class TestFileHost extends Host {
         return this.isTestFile(file) ? file : super.resolveFile(file, referer);
     }
 
-    async readFile(file: string, cancellationToken?: CancellationToken) {
-        return this.isTestFile(file) ? this.file.content : super.readFile(file, cancellationToken);
+    async readFile(file: string, cancelable?: Cancelable) {
+        return this.isTestFile(file) ? this.file.content : super.readFile(file, cancelable);
     }
 
-    readFileSync(file: string, cancellationToken?: CancellationToken) {
-        return this.isTestFile(file) ? this.file.content : super.readFileSync(file, cancellationToken);
+    readFileSync(file: string, cancelable?: Cancelable) {
+        return this.isTestFile(file) ? this.file.content : super.readFileSync(file, cancelable);
     }
 }
 

--- a/src/tests/scanner-tests.ts
+++ b/src/tests/scanner-tests.ts
@@ -1,15 +1,31 @@
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { assert } from "chai";
+import { CancelToken } from "@esfx/async-canceltoken";
 import { DiagnosticMessages } from "../diagnostics";
 import { SourceFile } from "../nodes";
 import { Scanner } from "../scanner";
-import { CancellationTokenSource } from "prex";
-import { assert } from "chai";
 
 describe("Scanner", () => {
     it("cancelable", () => {
         const sourceFile = new SourceFile("cancelable.grammar", "", []);
         const diagnostics = new DiagnosticMessages();
         diagnostics.setSourceFile(sourceFile);
-        const cts = new CancellationTokenSource();
+        const cts = CancelToken.source();
         const scanner = new Scanner(sourceFile.filename, sourceFile.text, diagnostics, cts.token);
         cts.cancel();
         assert.throws(() => scanner.scan());

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -9,7 +9,8 @@
         "emitDecoratorMetadata": true,
         "declaration": true,
         "strict": true,
-        "stripInternal": true
+        "stripInternal": true,
+        "noUnusedLocals": true
     },
     "include": [
         "**/*.ts"

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -1,4 +1,20 @@
-import { SyntaxKind, TokenKind } from "./tokens";
+/*!
+ *  Copyright 2015 Ron Buckton (rbuckton@chronicles.org)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { TokenKind } from "./tokens";
 import {
     Node,
     Token,
@@ -12,7 +28,6 @@ import {
     OneOfList,
     Terminal,
     SymbolSet,
-    Assertion,
     InvalidAssertion,
     EmptyAssertion,
     LookaheadAssertion,
@@ -25,7 +40,6 @@ import {
     ArgumentList,
     Nonterminal,
     OneOfSymbol,
-    LexicalSymbol,
     PlaceholderSymbol,
     InvalidSymbol,
     ButNotSymbol,
@@ -37,8 +51,6 @@ import {
     Production,
     Import,
     Define,
-    MetaElement,
-    SourceElement
 } from "./nodes";
 
 export abstract class NodeVisitor {


### PR DESCRIPTION
Deprecates usage of `CancellationToken` from `prex@0.4.2` in favor `Cancelable` in `@esfx/cancelable`. Existing code *should* continue to compile/run successfully as I pass a `CancelToken` that has been modified to include the members of `CancellationToken`.

As of `prex@0.4.6`, the `CancellationToken` type is also `Cancelable`.