### PR TITLE
Add a noUnusedParameters option

### DIFF
--- a/baselines/reference/parameters/noUnusedParameters.grammar.diagnostics
+++ b/baselines/reference/parameters/noUnusedParameters.grammar.diagnostics
@@ -1,0 +1,3 @@
+/// parameters/noUnusedParameters.grammar:
+parameters/noUnusedParameters.grammar(4,5): error GM2008: Parameter 'A' is unused.
+parameters/noUnusedParameters.grammar(7,5): error GM2008: Parameter 'A' is unused.

--- a/baselines/reference/parameters/noUnusedParameters.grammar.emu.html
+++ b/baselines/reference/parameters/noUnusedParameters.grammar.emu.html
@@ -1,0 +1,18 @@
+<emu-production name="Foo" params="A" type="lexical">
+    <emu-rhs a="407d5729"><emu-nt params="+A">Bar</emu-nt></emu-rhs>
+</emu-production>
+<emu-production name="Bar" params="A" type="lexical">
+    <emu-rhs a="150383a9"><emu-t>x</emu-t></emu-rhs>
+</emu-production>
+<emu-production name="Baz" params="A" type="lexical">
+    <emu-rhs a="150383a9"><emu-t>x</emu-t></emu-rhs>
+</emu-production>
+<emu-production name="Baz" params="A" type="lexical">
+    <emu-rhs a="f85c2655" constraints="~A"><emu-t>y</emu-t></emu-rhs>
+</emu-production>
+<emu-production name="Quxx" params="A" type="lexical">
+    <emu-rhs a="150383a9"><emu-t>x</emu-t></emu-rhs>
+</emu-production>
+<emu-production name="Quxx" params="A" type="lexical">
+    <emu-rhs a="a19d5bc9"><emu-nt params="?A">Baz</emu-nt></emu-rhs>
+</emu-production>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grammarkdown",
-  "version": "2.0.12",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,7 +8,6 @@
       "version": "1.0.0-pre.13",
       "resolved": "https://registry.npmjs.org/@esfx/async-canceltoken/-/async-canceltoken-1.0.0-pre.13.tgz",
       "integrity": "sha512-D8OF4aZWRuJDW9FAV8D8JB4umDvBpd6VF82Pybh/tFJ9FqIjZ80aURPwYDhQkK+9coF//Qx3zfsLO6ifSpjJJQ==",
-      "dev": true,
       "requires": {
         "@esfx/cancelable": "^1.0.0-pre.13",
         "@esfx/collections-linkedlist": "^1.0.0-pre.13",
@@ -22,7 +21,6 @@
       "version": "1.0.0-pre.13",
       "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.13.tgz",
       "integrity": "sha512-JpcXOrEPh/AMaZ8OGWrjYq+o65/emqxZFnW7NRRS6x8nrHbbZTUHEJnQmjahXkjvliPBgsFqueaLphXP52ACug==",
-      "dev": true,
       "requires": {
         "@esfx/disposable": "^1.0.0-pre.13",
         "@esfx/internal-deprecate": "^1.0.0-pre.13",
@@ -35,7 +33,6 @@
       "version": "1.0.0-pre.13",
       "resolved": "https://registry.npmjs.org/@esfx/collection-core/-/collection-core-1.0.0-pre.13.tgz",
       "integrity": "sha512-jMOy2238UjUeHC0sRVaNeJ2koK/YLZxITKTLbZfWUJpfp/4UVmDO/npv0cxIcob59KdWRf5MONjgz2WdzNpU+A==",
-      "dev": true,
       "requires": {
         "@esfx/internal-deprecate": "^1.0.0-pre.13",
         "@esfx/internal-guards": "^1.0.0-pre.11",
@@ -46,7 +43,6 @@
       "version": "1.0.0-pre.13",
       "resolved": "https://registry.npmjs.org/@esfx/collections-linkedlist/-/collections-linkedlist-1.0.0-pre.13.tgz",
       "integrity": "sha512-rddmq8BWGxo0rnobqexp1XTF1iJqezxemPHgAvJBD8dLVowrZ/ffVkj5wjmbHtaTh2qwHhJ/kThyyT9/RzLKJg==",
-      "dev": true,
       "requires": {
         "@esfx/collection-core": "^1.0.0-pre.13",
         "@esfx/equatable": "^1.0.0-pre.13",
@@ -58,7 +54,6 @@
       "version": "1.0.0-pre.13",
       "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.13.tgz",
       "integrity": "sha512-rTypmtVgC8nx3gfxHIX96By2UNub0ewRthxUiWE1x/+NTSfzGOHVpVu0H8DF+VQJND04E6srcwwbO+Hpek16GA==",
-      "dev": true,
       "requires": {
         "@esfx/internal-deprecate": "^1.0.0-pre.13",
         "@esfx/internal-guards": "^1.0.0-pre.11",
@@ -70,7 +65,6 @@
       "version": "1.0.0-pre.13",
       "resolved": "https://registry.npmjs.org/@esfx/equatable/-/equatable-1.0.0-pre.13.tgz",
       "integrity": "sha512-2vYdGp5yCPB0HFLqetOqTVBuUfxos38La195fkeGJilNF/hZ1Zvwx2nrMuwyypKn5lyCZ9GgxJ5XlvY/rV8EwA==",
-      "dev": true,
       "requires": {
         "@esfx/internal-deprecate": "^1.0.0-pre.13",
         "@esfx/internal-hashcode": "^1.0.0-pre.9",
@@ -81,7 +75,6 @@
       "version": "1.0.0-pre.13",
       "resolved": "https://registry.npmjs.org/@esfx/internal-deprecate/-/internal-deprecate-1.0.0-pre.13.tgz",
       "integrity": "sha512-uF4EhrILmUJdcDkSQNsr+33XEKaMj92/8804VIHswytdbwaQjQ85dbj1bSB9TFsXG2zkZtJo09NKNQ9p7NvTPQ==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -90,7 +83,6 @@
       "version": "1.0.0-pre.11",
       "resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.11.tgz",
       "integrity": "sha512-DnRXkwwSrqIaml+sAm/zzpfDOCBnZkzflmGB833AqVYbgopO7xPBobngxqGBhYjutgTmVuXV3GKP0g08h4mQEw==",
-      "dev": true,
       "requires": {
         "@esfx/type-model": "^1.0.0-pre.11",
         "tslib": "^1.9.3"
@@ -100,7 +92,6 @@
       "version": "1.0.0-pre.9",
       "resolved": "https://registry.npmjs.org/@esfx/internal-hashcode/-/internal-hashcode-1.0.0-pre.9.tgz",
       "integrity": "sha512-TJ43s8iE6wnVHT3CyIaRIZRlOOFIlK7m0hk1fl2D0ZzrTLtw5GUEcMFqV2sIGkGXrEKjEqwkuK1/vPQl9rikvA==",
-      "dev": true,
       "requires": {
         "@esfx/internal-murmur3": "^1.0.0-pre.5",
         "tslib": "^1.9.3"
@@ -110,7 +101,6 @@
       "version": "1.0.0-pre.5",
       "resolved": "https://registry.npmjs.org/@esfx/internal-murmur3/-/internal-murmur3-1.0.0-pre.5.tgz",
       "integrity": "sha512-Jq+oO1sbxWeUvIoyS7tOF+jg1KLitOOD1/TPTmdYGu/ss53kM8GXaGw5H4x/g07tQfQdC3QyDlepxK/dvoQqoQ==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -118,14 +108,12 @@
     "@esfx/internal-tag": {
       "version": "1.0.0-pre.6",
       "resolved": "https://registry.npmjs.org/@esfx/internal-tag/-/internal-tag-1.0.0-pre.6.tgz",
-      "integrity": "sha512-nODidP9/RBLqX39HL12IhFLgaoBHrC5nrm6D/BwquCGNoPQI9EXNPau+IdmGqeUcaMoVOFLFOkYtnHU52RVngw==",
-      "dev": true
+      "integrity": "sha512-nODidP9/RBLqX39HL12IhFLgaoBHrC5nrm6D/BwquCGNoPQI9EXNPau+IdmGqeUcaMoVOFLFOkYtnHU52RVngw=="
     },
     "@esfx/type-model": {
       "version": "1.0.0-pre.11",
       "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.11.tgz",
       "integrity": "sha512-ImM8fj0HFE2GRPRq+q1xnW3kNaIbZscpJfWjGyeo9KdMxKoI75bJebsA3XK6AH9zbEWba+521V+m6NDvDhcnSw==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -5053,9 +5041,13 @@
       "dev": true
     },
     "prex": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/prex/-/prex-0.4.2.tgz",
-      "integrity": "sha512-TZhR8PdeMRoLo2DzmaG/9uc21oda84O9H4eyKyESrJDYA443jd+acUnOXh3RsC0FCK+ro5e5jkzjcT0gEBF/IA=="
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/prex/-/prex-0.4.7.tgz",
+      "integrity": "sha512-ulhl3iyjmAW/GroRQJN4CG+pC6KJ+W+deNRBkEShQwe16wLP9k92+x6RmLJuLiVSGkbxhnAqHpGdJJCh3bRpUQ==",
+      "requires": {
+        "@esfx/cancelable": "^1.0.0-pre.13",
+        "@esfx/disposable": "^1.0.0-pre.13"
+      }
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -6064,8 +6056,7 @@
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-      "dev": true
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "prex": "^0.4.7",
     "@esfx/async-canceltoken": "^1.0.0-pre.13",
-    "@esfx/cancelable": "^1.0.0-pre.13"
+    "@esfx/cancelable": "^1.0.0-pre.13",
+    "prex": "^0.4.7"
   }
 }

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -18,7 +18,7 @@ import { CancellationToken } from "prex";
 import { Cancelable } from "@esfx/cancelable";
 import { SyntaxKind } from "./tokens";
 import { Symbol, SymbolKind, SymbolTable } from "./symbols";
-import { SourceFile, Production, Parameter, Node, Declaration } from "./nodes";
+import { SourceFile, Production, Parameter, Node, Declaration, Identifier } from "./nodes";
 import { toCancelToken } from "./core";
 
 export class BindingTable {
@@ -55,6 +55,11 @@ export class BindingTable {
         }
 
         return undefined;
+    }
+
+    public getSourceFile(node: Node | undefined): SourceFile | undefined {
+        return node?.kind === SyntaxKind.SourceFile ? node as SourceFile :
+            this.getAncestor(node, SyntaxKind.SourceFile) as SourceFile | undefined;
     }
 
     public hasSymbol(node: Node | undefined): boolean {
@@ -154,7 +159,7 @@ export class BindingTable {
     }
 
     /* @internal */
-    public setSymbol(node: Node | undefined, symbol: Symbol | undefined): void {
+    public setSymbol(node: Identifier | undefined, symbol: Symbol | undefined): void {
         if (node && symbol) {
             this.setSymbolForNode(node, symbol);
             this.addReferenceToSymbol(symbol, node);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,7 @@ const knownOptions: KnownOptions = {
     "noEmitOnError": { type: "boolean", description: "Does not emit output if there are errors." },
     "noChecks": { type: "boolean", description: "Does not perform static checking of the grammar." },
     "noStrictParametricProductions": { type: "boolean", description: "Does not perform strict checking of parametric productions and nonterminals." },
+    "noUnusedParameters": { type: "boolean", description: "Disallow unused parameters in productions." },
     "emitLinks": { type: "boolean", hidden: true },
     "usage": { aliasFor: ["--help"], hidden: true },
     "md": { aliasFor: ["--format", "markdown"], hidden: true },

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -48,6 +48,7 @@ export const Diagnostics = makeDiagnostics({
     Production_0_does_not_have_a_parameter_named_1_: { code: 2004, message: "Production '{0}' does not have a parameter named '{1}'." },
     Production_0_is_missing_parameter_1_All_definitions_of_production_0_must_specify_the_same_formal_parameters: { code: 2006, message: "Production '{0}' is missing parameter '{1}'. All definitions of production '{0}' must specify the same formal parameters." },
     There_is_no_argument_given_for_parameter_0_: { code: 2007, message: "There is no argument given for parameter '{0}'." },
+    Parameter_0_is_unused: { code: 2008, message: "Parameter '{0}' is unused." }
 });
 
 export interface DiagnosticInfo {

--- a/src/options.ts
+++ b/src/options.ts
@@ -35,6 +35,7 @@ export interface CompilerOptions {
     noEmit?: boolean;
     noEmitOnError?: boolean;
     noStrictParametricProductions?: boolean;
+    noUnusedParameters?: boolean;
     format?: EmitFormat;
     out?: string;
     emitLinks?: boolean;

--- a/src/tests/resources/parameters/noUnusedParameters.grammar
+++ b/src/tests/resources/parameters/noUnusedParameters.grammar
@@ -1,0 +1,20 @@
+// https://github.com/rbuckton/grammarkdown/issues/46
+@define noUnusedParameters true
+
+Foo[A] ::
+  Bar[+A]
+
+Bar[A] ::
+  `x`
+
+Baz[A] ::
+  `x`
+
+Baz[A] ::
+  [~A] `y`
+
+Quxx[A] ::
+  `x`
+
+Quxx[A] ::
+  Baz[?A]


### PR DESCRIPTION
This adds support for a `--noUnusedParameters` option (along with `@define noUnusedParameters <true|false>`) which reports errors when production parameters are unused in any right-hand-side.

For example:

```grammarkdown
// https://github.com/rbuckton/grammarkdown/issues/46
@define noUnusedParameters true

Foo[A] :: // error: Parameter 'A' is unused.
  Bar[+A]

Bar[A] :: // error: Parameter 'A' is unused.
  `x`

Baz[A] :: // no error. Parameter 'A' is referenced in a merged alternative below. 
  `x`

Baz[A] ::
  [~A] `y`

Quxx[A] :: // no error. Parameter 'A' is referenced in a merged alternative below. 
  `x`

Quxx[A] ::
  Baz[?A]
```

Fixes #46

/cc @bakkot 