### PR TITLE
Fix check for nonterminal in prose fragment

### DIFF
--- a/baselines/reference/assertions/proseAssertion.2.grammar.emu.html
+++ b/baselines/reference/assertions/proseAssertion.2.grammar.emu.html
@@ -1,0 +1,9 @@
+<emu-production name="HexDigits" params="Sep" type="lexical" collapsed>
+    <emu-rhs a="37b9c04c"><emu-gann>empty</emu-gann></emu-rhs>
+</emu-production>
+<emu-production name="NotCodePoint" type="lexical" collapsed>
+    <emu-rhs a="c53626dc">
+        <emu-nt params="~Sep">HexDigits</emu-nt>
+        <emu-gmod>but only if MV of <emu-nt>HexDigits</emu-nt> &gt; 0x10FFFF</emu-gmod>
+    </emu-rhs>
+</emu-production>

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -870,7 +870,7 @@ export class Checker {
     private checkProseFragment(fragment: ProseFragment): void {
         switch (fragment.kind) {
             case SyntaxKind.Nonterminal:
-                this.checkNonterminal(<Nonterminal>fragment, /*allowOptional*/ false);
+                this.checkNonterminal(<Nonterminal>fragment, /*allowOptional*/ false, /*allowArguments*/ false);
                 break;
 
             case SyntaxKind.Terminal:
@@ -1000,7 +1000,7 @@ export class Checker {
                 break;
 
             case SyntaxKind.Nonterminal:
-                this.checkNonterminal(<Nonterminal>node, allowOptional);
+                this.checkNonterminal(<Nonterminal>node, allowOptional, /*allowArguments*/ true);
                 break;
 
             case SyntaxKind.PlaceholderSymbol:
@@ -1011,6 +1011,16 @@ export class Checker {
                 this.reportInvalidSymbol(<LexicalSymbol>node);
                 break;
         }
+    }
+
+    private checkGrammarNonTerminal(node: Nonterminal, allowOptional: boolean, allowArguments: boolean) {
+        if (this.checkGrammarOptionalSymbol(node, allowOptional)) {
+            return true;
+        }
+        if (!allowArguments && node.argumentList) {
+            return this.reportGrammarErrorForNode(node.argumentList, Diagnostics.Unexpected_token_0_, tokenToString(node.argumentList.openParenToken.kind));
+        }
+        return false;
     }
 
     private checkGrammarOptionalSymbol(node: OptionalSymbol, allowOptional: boolean) {
@@ -1069,10 +1079,10 @@ export class Checker {
     private checkPlaceholder(node: PlaceholderSymbol): void {
     }
 
-    private checkNonterminal(node: Nonterminal, allowOptional: boolean = false): void {
-        this.checkGrammarOptionalSymbol(node, allowOptional);
+    private checkNonterminal(node: Nonterminal, allowOptional: boolean = false, allowArguments: boolean = true): void {
+        this.checkGrammarNonTerminal(node, allowOptional, allowArguments);
 
-        if (this.noStrictParametricProductions) {
+        if (this.noStrictParametricProductions || !allowArguments) {
             this.checkNonterminalNonStrict(node);
         }
         else {

--- a/src/tests/resources/assertions/proseAssertion.2.grammar
+++ b/src/tests/resources/assertions/proseAssertion.2.grammar
@@ -1,0 +1,2 @@
+HexDigits[Sep] :: [empty]
+NotCodePoint :: HexDigits[~Sep] [> but only if MV of |HexDigits| > 0x10FFFF]


### PR DESCRIPTION
Disallows production arguments in a prose assertion.

Fixes #52