### PR TITLE
Emit 'ins/del' around terminals in a oneof list

### DIFF
--- a/baselines/reference/html/aroundTerminalInOneOf.grammar.emu.html
+++ b/baselines/reference/html/aroundTerminalInOneOf.grammar.emu.html
@@ -1,0 +1,3 @@
+<emu-production name="A" type="lexical" oneof>
+    <emu-rhs>a <ins><emu-t>b</emu-t></ins> c</emu-rhs>
+</emu-production>

--- a/baselines/reference/html/aroundTerminalInOneOf.grammar.emu.html
+++ b/baselines/reference/html/aroundTerminalInOneOf.grammar.emu.html
@@ -1,3 +1,3 @@
 <emu-production name="A" type="lexical" oneof>
-    <emu-rhs>a <ins><emu-t>b</emu-t></ins> c</emu-rhs>
+    <emu-rhs>a <ins>b</ins> c</emu-rhs>
 </emu-production>

--- a/src/emitter/ecmarkup.ts
+++ b/src/emitter/ecmarkup.ts
@@ -113,7 +113,13 @@ export class EcmarkupEmitter extends Emitter {
                     this.writer.write(` `);
                 }
 
-                this.emitTextContent(node.terminals[i]);
+                const terminal = node.terminals[i];
+                if (terminal.leadingHtmlTrivia || terminal.trailingHtmlTrivia) {
+                    this.emitNode(terminal);
+                }
+                else {
+                    this.emitTextContent(node.terminals[i]);
+                }
             }
         }
 

--- a/src/emitter/ecmarkup.ts
+++ b/src/emitter/ecmarkup.ts
@@ -114,12 +114,9 @@ export class EcmarkupEmitter extends Emitter {
                 }
 
                 const terminal = node.terminals[i];
-                if (terminal.leadingHtmlTrivia || terminal.trailingHtmlTrivia) {
-                    this.emitNode(terminal);
-                }
-                else {
-                    this.emitTextContent(node.terminals[i]);
-                }
+                this.emitLeadingHtmlTriviaOfNode(terminal);
+                this.emitTextContent(terminal);
+                this.emitTrailingHtmlTriviaOfNode(terminal);
             }
         }
 

--- a/src/tests/resources/html/aroundTerminalInOneOf.grammar
+++ b/src/tests/resources/html/aroundTerminalInOneOf.grammar
@@ -1,0 +1,2 @@
+A :: one of
+    `a` <ins>`b`</ins> `c`


### PR DESCRIPTION
Emits html trivia surrounding a terminal in a `oneof` list. This also requires that we emit the `<emu-t>` tag around each terminal due to https://github.com/tc39/ecmarkup/issues/247.

Fixes: #32