### PR TITLE
Report an error for non-renderable html trivia

### DIFF
--- a/baselines/reference/html/aroundProduction.grammar.diagnostics
+++ b/baselines/reference/html/aroundProduction.grammar.diagnostics
@@ -1,0 +1,3 @@
+/// html/aroundProduction.grammar:
+html/aroundProduction.grammar(9,16): error GM1010: HTML trivia not allowed here.
+html/aroundProduction.grammar(12,16): error GM1010: HTML trivia not allowed here.

--- a/baselines/reference/html/aroundProduction.grammar.emu.html
+++ b/baselines/reference/html/aroundProduction.grammar.emu.html
@@ -1,0 +1,13 @@
+<ins><emu-production name="A" type="lexical">
+    <emu-rhs a="0185ce89"><emu-t>b</emu-t></emu-rhs>
+</emu-production></ins>
+<ins><emu-production name="A" type="lexical">
+    <emu-rhs a="0185ce89"><emu-t>b</emu-t></emu-rhs>
+</emu-production></ins>
+<ins><emu-production name="A" type="lexical">
+    <ins><emu-rhs a="0185ce89"><emu-t>b</emu-t></emu-rhs>
+    </ins>
+</emu-production>
+<ins><emu-production name="A" type="lexical">
+    <emu-rhs a="0185ce89"><emu-t>b</emu-t></emu-rhs>
+</emu-production>

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -41,6 +41,7 @@ export const Diagnostics = makeDiagnostics({
     Production_expected: { code: 1007, message: "Production expected." },
     Unterminated_identifier_literal: { code: 1008, message: "Unterminated identifier literal." },
     Obsolete_0_: { code: 1009, message: "Obsolete: {0}", warning: true },
+    Html_trivia_not_allowed_here: { code: 1010, message: "HTML trivia not allowed here." },
 
     Cannot_find_name_0_: { code: 2000, message: "Cannot find name: '{0}'." },
     Duplicate_identifier_0_: { code: 2001, message: "Duplicate identifier: '{0}'." },

--- a/src/tests/resources/html/aroundProduction.grammar
+++ b/src/tests/resources/html/aroundProduction.grammar
@@ -1,0 +1,13 @@
+<ins>A ::
+    `b`</ins>
+
+<ins>
+A ::
+    `b`
+</ins>
+
+<ins>A ::</ins>
+    <ins>`b`</ins>
+
+<ins>A ::</ins>
+    `b`


### PR DESCRIPTION
Unfortunately this doesn't as much *fix* #33 as it reports an error if you try to write html trivia in a grammarkdown production where it is not possible to render it.

Fixes: #33