### PR TITLE
fix typo in docs

### DIFF
--- a/src/docs/overwrite/coreasynchost.md
+++ b/src/docs/overwrite/coreasynchost.md
@@ -14,7 +14,7 @@ const files = new Map([
 ]);
 const host = new CoreAsyncHost({
   ignoreCase: false,
-  useBuiltinGrammers: false,
+  useBuiltinGrammars: false,
   resolveFile: file => file,
   readFile: file => files.get(file)
 });

--- a/src/docs/overwrite/coresynchost.md
+++ b/src/docs/overwrite/coresynchost.md
@@ -13,7 +13,7 @@ const files = new Map([
 ]);
 const host = new CoreSyncHost({
   ignoreCase: false,
-  useBuiltinGrammers: false,
+  useBuiltinGrammars: false,
   resolveFile: file => file,
   readFileSync: file => files.get(file)
 });


### PR DESCRIPTION
I think the HTML probably needs to be rebuilt too, but I couldn't figure out how to do it. There's no script in `package.json` which is suggestive of "this will rebuild the docs". I looked in "gulpfile.js", which seems to be used to handle various build tasks, but the only obvious task there is "docs", and attempting to run that fails with

```
[17:04:47] Starting 'docfx'...
/bin/sh: docfx: command not found
[17:04:47] 'docfx' errored after 6.18 ms
```
at which point I gave up.