### PR TITLE
Propagate newline CLI option to compiler

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,6 +87,7 @@ async function performCompilation(options: ParsedCommandLine): Promise<void> {
     if (options.emitLinks) compilerOptions.emitLinks = true;
     if (options.diagnostics) compilerOptions.diagnostics = true;
     compilerOptions.format = options.format || EmitFormat.markdown;
+    compilerOptions.newLine = options.newLine;
 
     performance.mark("beforeCompile");
 


### PR DESCRIPTION
I found that `--newLine LF` did not have the desired effect on Windows. It seems that the command line option wasn't getting passed on to the compiler.