### PR TITLE
doc: Fix description for production syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ NamedImports : `{` ImportList `}`
 NamedImports : `{` ImportList `,` `}`
 ```
 
-You may also specify multiple left-hand-side sentences for a single production by indenting them:
+You may also specify multiple right-hand-side sentences for a single production by indenting them:
 
 ```
 NamedImports :


### PR DESCRIPTION
In the syntax documentation for productions, it says "multiple left-hand-size sentences" where (I believe) it should be "multiple right-hand-side sentences".